### PR TITLE
bytes: Fix bad buffer initialization

### DIFF
--- a/bytes/buffer.go
+++ b/bytes/buffer.go
@@ -42,10 +42,10 @@ func (bp *BufferPool) Cap() int {
 
 // Clear discards all the buffers in then pool.
 func (bp *BufferPool) Clear() {
-	clearing:
+clearing:
 	for {
 		select {
-		case <- bp.pool:
+		case <-bp.pool:
 		default:
 			break clearing
 		}
@@ -78,6 +78,6 @@ func (bp *BufferPool) Len() int {
 }
 
 func newBufferL(l int) *bytes.Buffer {
-	s := make([]byte, l)
+	s := make([]byte, 0, l)
 	return bytes.NewBuffer(s)
 }

--- a/bytes/buffer_test.go
+++ b/bytes/buffer_test.go
@@ -32,7 +32,7 @@ func TestBufferPool_Add(t *testing.T) {
 	bp.Add(nil)
 	buf := bp.Get()
 
-	if buf.Len() != max {
+	if buf.Cap() != max {
 		t.Errorf("the buffer pool created a buffer with bad size")
 	}
 
@@ -41,7 +41,7 @@ func TestBufferPool_Add(t *testing.T) {
 	bp.Add(bytes.NewBuffer(make([]byte, 15)))
 	buf = bp.Get()
 
-	if buf.Len() != max {
+	if buf.Cap() != max {
 		t.Errorf("the buffer pool reused a buffer with bad size")
 	}
 


### PR DESCRIPTION
Since buffers were initialized with non-zero length, write operations
returned an EOF error.

See also: See https://golang.org/pkg/bytes/#NewBuffer
Fixes: #4